### PR TITLE
Fix a bug in the httpkey JScript keyer

### DIFF
--- a/data/jscript/keyers/httpkey.xml
+++ b/data/jscript/keyers/httpkey.xml
@@ -22,6 +22,6 @@ function GetHttpKey(url, ua) {
 }
   </function>
   <caller>
-combos.push("{{index .Inputs 0}}", "{{index .Inputs 1}}");
+combos.push(GetHttpKey("{{index .Inputs 0}}", "{{index .Inputs 1}}"));
   </caller>
 </keyer> 


### PR DESCRIPTION
Add the function GetHttpKey to take the URL and the user-agent as parameters instead of using them directly in key combinations.